### PR TITLE
docs: code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+## Introduction
+
+Deque is committed to providing a safe, inclusive, and welcoming virtual environment for contributors.
+
+We created this policy not because we anticipate bad behavior, but because we believe that articulating our values and obligations to one another reinforces a level of respect among contributors and because having a code of conduct provides us with clear avenues to correct our virtual culture should it ever stray from that course.
+
+## Code of Conduct Policy
+
+We expect all contributors to Deque open-source projects to uphold the principles of this Code of Conduct. We do not tolerate disruptive or disrespectful behavior, messages, images, or interactions by any participant, in any form.
+
+We will not tolerate harassment or discrimination based on age, ancestry, color, gender identity or expression, national origin, physical or mental disability, religion, sexual orientation, or any other characteristic.
+
+## Enforcement and Reporting
+
+Contributors asked to stop any harassing behavior are expected to comply immediately; regardless, Deque reserves the right to remove or block anyone from any repository at the discretion of Deque employees.
+
+If you have any concerns, please contact a code-owner or other Deque employee via direct message on the [axe Community Slack](https://accessibility.deque.com/axe-community) with details about the nature of the concern.


### PR DESCRIPTION
This PR brings over the Code of Conduct previously established in the `dev-process` repo.