### PR TITLE
feat: Add default Issue Template and Workflows for A11Y metrics

### DIFF
--- a/ISSUE_TEMPLATE/accessibility_violation.md
+++ b/ISSUE_TEMPLATE/accessibility_violation.md
@@ -1,0 +1,167 @@
+---
+name: Accessibility Violation
+about: Document an accessibility violation to be fixed
+title: '[A11Y] '
+labels: ['A11Y']
+assignees: ''
+
+---
+
+<!--
+Thank you for taking the time to create this Accessibility Issue!
+-->
+## Issue Details
+---
+### Short Description
+<!-- Please provide a short descritpion of the issue -->
+
+
+
+### Impact
+<!-- Please select the impact by putting an `x` in the `[ ]` like so `[x]` -->
+- [ ] Blocker
+- [ ] Serious
+- [ ] Critical
+- [ ] Moderate
+- [ ] Minor
+
+### Steps To Reproduce:
+<!--
+Example: steps to reproduce the behavior:
+1. In this environment...
+2. With this config...
+3. Run '...'
+4. See error...
+-->
+
+
+
+### Current Behavior:
+<!-- A concise description of what you're experiencing. -->
+
+
+
+### Expected Behavior:
+<!-- A concise description of what you expected to happen or help for how to fix this issue. -->
+
+
+
+---
+## Additional Context
+
+### Auditor ID / URL 
+<!-- If this was found in manual testing, provide a link to the Auditor test run issue -->
+
+
+### Additional Details
+<!-- Add any other context about the feature request here. -->
+
+
+<details>
+<summary>Expand for extra context</summary>
+
+<!-- Select any / all that apply by putting an `x` in the `[ ]` like so `[x]` -->
+- [ ] Exists in Production
+- [ ] Discovered during VPAT
+- [ ] Discovered by Customer <!-- Provide link to customer ticket below -->
+- [ ] Found using NVDA
+- [ ] Found using Chrome Screen Reader
+- [ ] Found with special configuration <!-- Specify the additional config below -->
+</details>
+
+---
+## Screenshots <!-- Please provide links to relevant screenshots of the issue -->
+
+
+
+
+---
+## Success Criteria
+<!-- Select any / all success criteria that apply by putting an `x` in the `[ ]` like so `[x]` -->
+### 1. Perceivable
+<details> 
+<summary>Expand</summary>
+
+#### 1.1 Text Alternatives
+- [ ] 1.1.1 Non-text Content
+#### 1.2 Time-based Media
+- [ ] 1.2.1 Audio-only and Video-only (Prerecorded)
+- [ ] 1.2.2 Captions (Prerecorded)
+- [ ] 1.2.3 Audio Description or Media Alternative (Prerecorded)
+- [ ] 1.2.4 Captions (Live)
+- [ ] 1.2.5 Audio Description (Prerecorded)
+#### 1.3 Info and Relationships
+- [ ] 1.3.1 Info and Relationships
+- [ ] 1.3.2 Meaningful Sequence
+- [ ] 1.3.3 Sensory Characteristics
+- [ ] 1.3.4 Orientation
+- [ ] 1.3.5 Identify Input Purpose
+#### 1.4 Distinguishable
+- [ ] 1.4.1 Use of Color
+- [ ] 1.4.2 Audio Control
+- [ ] 1.4.3 Contrast (Minimum)
+- [ ] 1.4.4 Resize text
+- [ ] 1.4.5 Images of Text
+- [ ] 1.4.10 Reflow
+- [ ] 1.4.11 Non-text Contrast
+- [ ] 1.4.12 Text Spacing
+- [ ] 1.4.13 Content on Hover or Focus
+</details>
+
+### 2. Operable
+<details> 
+<summary>Expand</summary>
+
+#### 2.1 Keyboard Accessible
+- [ ] 2.1.1 Keyboard
+- [ ] 2.1.2 No Keyboard Trap
+- [ ] 2.1.4 Character Key Shortcuts
+#### 2.2 Enough Time
+- [ ] 2.2.1 Timing Adjustable
+- [ ] 2.2.2 Pause, Stop, Hide
+#### 2.3 Seizures and Physical Reactions
+- [ ] 2.3.1 Three Flashes or Below Threshold
+#### 2.4 Navigable
+- [ ] 2.4.1 Bypass Blocks
+- [ ] 2.4.2 Page Titled
+- [ ] 2.4.3 Focus Order
+- [ ] 2.4.4 Link Purpose (In Context)
+- [ ] 2.4.5 Multiple Ways
+- [ ] 2.4.6 Headings and Labels
+- [ ] 2.4.7 Focus Visible
+#### 2.5 Input Modalities
+- [ ] 2.5.1 Pointer Gestures
+- [ ] 2.5.2 Pointer Cancellation
+- [ ] 2.5.3 Label in Name
+- [ ] 2.5.4 Motion Actuation
+</details>
+
+### 3. Understandable
+<details> 
+<summary>Expand</summary>
+
+#### 3.1 Readable
+- [ ] 3.1.1 Language of Page
+- [ ] 3.1.2 Language of Parts
+#### 3.2 Predictable
+- [ ] 3.2.1 On Focus
+- [ ] 3.2.2 On Input
+- [ ] 3.2.3 Consistent Navigation
+- [ ] 3.2.4 Consistent Identification
+#### 3.3 Input Assistance
+- [ ] 3.3.1 Error Identification
+- [ ] 3.3.2 Labels or Instructions
+- [ ] 3.3.3 Error Suggestion
+- [ ] 3.3.4 Error Prevention (Legal, Financial, Data)
+</details>
+
+### 4. Robust
+<details>
+<summary>Expand</summary>
+
+#### 4.1 Compatible
+- [ ] 4.1.1 Parsing
+- [ ] 4.1.2 Name, Role, Value
+- [ ] 4.1.3 Status Messages
+</details>
+

--- a/workflows/categorizer.yml
+++ b/workflows/categorizer.yml
@@ -1,0 +1,16 @@
+name: "Issue Categorizer"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * SUN' # At 00:00 on Sunday
+jobs:
+  categorize:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dequelabs/action-a11y-issue-categorizer@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      
+
+        

--- a/workflows/labeler.yml
+++ b/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dequelabs/action-vpat-labels@main
+    - uses: dequelabs/action-a11y-issue-labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        include-title: 1


### PR DESCRIPTION
This adds three actions and an Issue Template to all repos in Deque.

* Accessibility Issue Template - Allows for easily creating commonized Accessibility Issues in GitHub repos
* A11Y Issue Labeler Action - Automatically label issues based on the content of the issue
* A11Y Issue Categorizer - Automatically add CAT labels to issues based on when they were created and their assigned labels. Executes every Sunday and can be launched manually.

Note: Actions can be enabled by creating the `.github/a11y-metrics.yaml` file with the contents: `enabled: true`.